### PR TITLE
Fix typo for installing packages

### DIFF
--- a/vscode/rootfs/etc/cont-init.d/80-user-packages.sh
+++ b/vscode/rootfs/etc/cont-init.d/80-user-packages.sh
@@ -8,7 +8,7 @@ if bashio::config.has_value 'packages'; then
         || bashio::exit.nok 'Failed updating Ubuntu packages repository indexes'
 
     for package in $(bashio::config 'packages'); do
-        apt add -y "$package" \
+        apt install -y "$package" \
             || bashio::exit.nok "Failed installing package ${package}"
     done
 fi

--- a/vscode/rootfs/etc/cont-init.d/80-user-packages.sh
+++ b/vscode/rootfs/etc/cont-init.d/80-user-packages.sh
@@ -8,7 +8,7 @@ if bashio::config.has_value 'packages'; then
         || bashio::exit.nok 'Failed updating Ubuntu packages repository indexes'
 
     for package in $(bashio::config 'packages'); do
-        apt install -y "$package" \
+        apt-get install -y "$package" \
             || bashio::exit.nok "Failed installing package ${package}"
     done
 fi


### PR DESCRIPTION
# Proposed Changes

Tried to install `nano`. Saw an error. Saw the typo :smile: 
