### PR TITLE
Add in the other config dirs to the launch command... 

### DIFF
--- a/vscode/rootfs/etc/services.d/code/run
+++ b/vscode/rootfs/etc/services.d/code/run
@@ -29,4 +29,4 @@ export HASS_SERVER="http://hassio/homeassistant"
 export HASS_TOKEN="${HASSIO_TOKEN:-}"
 
 # Run the code server
-exec code-server "${options[@]}" /config
+exec code-server "${options[@]}" /config /share

--- a/vscode/rootfs/etc/services.d/code/run
+++ b/vscode/rootfs/etc/services.d/code/run
@@ -29,4 +29,4 @@ export HASS_SERVER="http://hassio/homeassistant"
 export HASS_TOKEN="${HASSIO_TOKEN:-}"
 
 # Run the code server
-exec code-server "${options[@]}" /config /share
+exec code-server "${options[@]}" /config /share /adons /backups


### PR DESCRIPTION
# Proposed Changes

I am currently using the core Nginx add-on and storing multiple configs in the /share directory. I'd like to be able to use VSCode to edit these as I have in the IDE add-on in the past. Once I installed this add-on, I noticed I could only access my HASS config by default, but the other config directories were accessible in the add file/folder dialogs, so I created this diff to include all the normal config dirs in addition to /config.

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/