### PR TITLE
Added .dash extension for YAML

### DIFF
--- a/vscode/rootfs/root/.code-server/settings.json
+++ b/vscode/rootfs/root/.code-server/settings.json
@@ -7,6 +7,9 @@
         "**/__pycache__/**": true,
         "**/deps/**": true
     },
+    "files.associations": {
+        "*.dash": "yaml"
+    },
     "editor.selectionClipboard": false,
     "terminal.integrated.copyOnSelection": true
 }


### PR DESCRIPTION
Added dash extension for YAML
This was requested as issue #18. This issue was closed as not possible at add-on level.  

# Proposed Changes

We need to add .dash file extension to have the HADashboard configuration files treated as YAML.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/