### PR TITLE
Update to code server to 1.868-vsc1.33.1 and add new telemetry disable flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ Example add-on configuration:
     ],
     "init_commands": [
       "ls -la"
-    ]
+    ],
+    "disable_telemetry": false
 }
 ```
 
@@ -126,6 +127,10 @@ time for the add-on._
 Customize your VSCode environment even more with the `init_commands` option.
 Add one or more shell commands to the list, and they will be executed every
 single time this add-on starts.
+
+### Option: `disable_telemetry`
+
+Disables annonymous usage telemetry data from being sent to code-server.
 
 ### Option: `leave_front_door_open`
 

--- a/vscode/Dockerfile
+++ b/vscode/Dockerfile
@@ -82,7 +82,7 @@ RUN \
     && locale-gen en_US.UTF-8 \
     \
     && curl -J -L -o /tmp/code.tar.gz \
-        "https://github.com/codercom/code-server/releases/download/1.792-vsc1.33.1/code-server1.792-vsc1.33.1-linux-x64.tar.gz" \
+        "https://github.com/codercom/code-server/releases/download/1.868-vsc1.33.1/code-server1.868-vsc1.33.1-linux-x64.tar.gz" \
     && tar zxvf \
         /tmp/code.tar.gz \
         --strip 1 -C /tmp \

--- a/vscode/config.json
+++ b/vscode/config.json
@@ -36,7 +36,8 @@
     "certfile": "fullchain.pem",
     "keyfile": "privkey.pem",
     "packages": [],
-    "init_commands": []
+    "init_commands": [],
+    "disable_telemetry": false
   },
   "schema": {
     "log_level": "match(^(trace|debug|info|notice|warning|error|fatal)$)?",
@@ -45,6 +46,7 @@
     "keyfile": "str",
     "packages": ["str"],
     "init_commands": ["str"],
+    "disable_telemetry": "bool?",
     "leave_front_door_open": "bool?"
   }
 }

--- a/vscode/rootfs/etc/services.d/code/run
+++ b/vscode/rootfs/etc/services.d/code/run
@@ -12,6 +12,7 @@ options+=(--user-data-dir "/data/vscode")
 options+=(--extensions-dir "/data/vscode/extensions")
 options+=(--host 127.0.0.1)
 options+=(--allow-http)
+options+=(--disable-telemetry)
 
 # Disable code authentication, we use HA authentication
 options+=(--no-auth)

--- a/vscode/rootfs/etc/services.d/code/run
+++ b/vscode/rootfs/etc/services.d/code/run
@@ -12,7 +12,10 @@ options+=(--user-data-dir "/data/vscode")
 options+=(--extensions-dir "/data/vscode/extensions")
 options+=(--host 127.0.0.1)
 options+=(--allow-http)
-options+=(--disable-telemetry)
+
+if bashio::config.true 'disable_telemetry'; then
+    options+=(--disable-telemetry)
+fi
 
 # Disable code authentication, we use HA authentication
 options+=(--no-auth)


### PR DESCRIPTION
# Proposed Changes

Two releases:

https://github.com/codercom/code-server/releases/tag/1.854-vsc1.33.1

https://github.com/codercom/code-server/releases/tag/1.868-vsc1.33.1

1.854 added a flag to opt out of telemetry


<blockquote><img src="https://avatars2.githubusercontent.com/u/20144034?s=400&v=4" width="48" align="right"><div><img src="https://github.githubassets.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/codercom/code-server">codercom/code-server</a></strong></div><div>Run VS Code on a remote server. Contribute to codercom/code-server development by creating an account on GitHub.</div></blockquote>
<blockquote><img src="https://avatars2.githubusercontent.com/u/20144034?s=400&v=4" width="48" align="right"><div><img src="https://github.githubassets.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/codercom/code-server">codercom/code-server</a></strong></div><div>Run VS Code on a remote server. Contribute to codercom/code-server development by creating an account on GitHub.</div></blockquote>