### PR TITLE
Exclude files matching pattern "._text"

### DIFF
--- a/vscode/rootfs/root/.code-server/settings.json
+++ b/vscode/rootfs/root/.code-server/settings.json
@@ -45,5 +45,8 @@
             "comments": false,
             "strings": true
         }
+    },
+    "files.exclude": {
+        "**/._*": true
     }
 }


### PR DESCRIPTION
# Proposed Changes

Hi Frenck, 

One change I routinely make after updating VSCode is to exclude the ._text.yaml files from the side bar.  The reason is these files are not valuable for updating Home Assistant's configuration.  I am not sure, but it seems that this might be unique to OSX.  Link that I followed: https://stackoverflow.com/questions/30140112/how-do-i-hide-certain-files-from-the-sidebar-in-visual-studio-code

If you think this would help others, please consider merging.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<blockquote><img src="https://cdn.sstatic.net/Sites/stackoverflow/img/apple-touch-icon@2.png?v=73d79a89bded" width="48" align="right"><div>Stack Overflow</div><div><strong><a href="https://stackoverflow.com/questions/30140112/how-do-i-hide-certain-files-from-the-sidebar-in-visual-studio-code">How do I hide certain files from the sidebar in Visual Studio Code?</a></strong></div><div>Using Microsoft's Visual Studio Code, how do I hide certain files and file patterns from appearing in the sidebar?

I want to hide .meta and .git style files</div></blockquote>