### PR TITLE
⬆️ Upgrades code-server to 2.1655-vsc1.39.2

### DIFF
--- a/vscode/Dockerfile
+++ b/vscode/Dockerfile
@@ -84,7 +84,7 @@ RUN \
     && locale-gen en_US.UTF-8 \
     \
     && curl -J -L -o /tmp/code.tar.gz \
-        "https://github.com/cdr/code-server/releases/download/2.1650-vsc1.39.2/code-server2.1650-vsc1.39.2-linux-x86_64.tar.gz" \
+        "https://github.com/cdr/code-server/releases/download/2.1655-vsc1.39.2/code-server2.1655-vsc1.39.2-linux-x86_64.tar.gz" \
     && tar zxvf \
         /tmp/code.tar.gz \
         --strip 1 -C /tmp \


### PR DESCRIPTION
# Proposed Changes

Upgrade code-server to https://github.com/cdr/code-server/releases/tag/2.1655-vsc1.39.2.

## Related Issues

- Add heartbeat file.
- Accept a workspace file from the command line.
- Properly surface exit codes.
- Fix unauthorized resource access.
- Fix passwords that contain a =.
- Fix issues when running code-server from within code-server's terminal.

<blockquote><img src="https://avatars0.githubusercontent.com/u/1375?s=400&v=4" width="48" align="right"><div><img src="https://github.githubassets.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/cdr/code-server">cdr/code-server</a></strong></div><div>Run VS Code on a remote server. Contribute to cdr/code-server development by creating an account on GitHub.</div></blockquote>