### PR TITLE
:sparkles: Add ESPHome VSCode extension

### DIFF
--- a/vscode/vscode.extensions
+++ b/vscode/vscode.extensions
@@ -1,3 +1,4 @@
+esphome.esphome-vscode#0.2.0
 keesschollaart.vscode-home-assistant#1.3.0
 lukas-tr.materialdesignicons-intellisense#1.5.5
 oderwat.indent-rainbow#7.4.0


### PR DESCRIPTION
# Proposed Changes

Adds https://marketplace.visualstudio.com/items?itemName=esphome.esphome-vscode
Still need to test the configuration:

> ESPHome Version 1.14 is required.
> 
> The plugin validates against ESPHome itself, so you will get the same errors. In order for that to work the plugin offers two options:
> 
> Use the ESPHome Dashboard, this can be the ESPHome running in Hass.io, in that case you will need to configure the add on to 'leave the front door open' and also give a tcp port in the addon for external access (in case you are only accessing via Ingress).
> 
> Use a local installation of ESPHome, if you can run esphome in your terminal, then you can use this option.
> 
> To select an option use VSCode built in settings editor and search for ESPHome. As this extension is under development for changes of these options to take effect you will have to reload VSCode window. If it doesn't seem to work try to reload VSCode window again.

<blockquote><img src="https://esphome.gallerycdn.vsassets.io/extensions/esphome/esphome-vscode/0.2.0/1572653218157/Microsoft.VisualStudio.Services.Icons.Default" width="48" align="right"><div><strong><a href="https://marketplace.visualstudio.com/items?itemName=esphome.esphome-vscode">ESPHome VSCode - Visual Studio Marketplace</a></strong></div><div>Extension for Visual Studio Code - Provide instant validation of ESPHome configuration files</div></blockquote>