### PR TITLE
Set ZSH as default shell

### DIFF
--- a/vscode/rootfs/root/.code-server/settings.json
+++ b/vscode/rootfs/root/.code-server/settings.json
@@ -26,6 +26,7 @@
         ".Trash-0/**": true
     },
     "terminal.integrated.copyOnSelection": true,
+    "terminal.integrated.shell.linux": "zsh",
     "yaml.customTags": [
         "!env_var scalar",
         "!include_dir_list scalar",


### PR DESCRIPTION
# Proposed Changes

> Set the default shell to `zsh`.  Currently, `sh` is the shell, and the experience for users leaves a lot to be desired - even the up arrow key does not recall the last command.  Setting the shell to `zsh` makes the arrow key work 👍 .