### PR TITLE
🚑 Fix MDI icon to new name

### DIFF
--- a/vscode/config.json
+++ b/vscode/config.json
@@ -6,7 +6,7 @@
   "url": "https://github.com/hassio-addons/addon-vscode",
   "ingress": true,
   "ingress_port": 1337,
-  "panel_icon": "mdi:visual-studio-code",
+  "panel_icon": "mdi:microsoft-visual-studio-code",
   "startup": "services",
   "init": false,
   "arch": ["aarch64", "amd64"],


### PR DESCRIPTION
Icon mdi:visual-studio-code was renamed to mdi:microsoft-visual-studio-code, please change your config, it will be removed in version 0.115.

# Proposed Changes
Rename "mdi:visual-studio-code" to "mdi:microsoft-visual-studio-code"

## Related Issues
No issues made so far