### PR TITLE
Fix CI badges to show the right status

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ SOFTWARE.
 [forum-shield]: https://img.shields.io/badge/community-forum-brightgreen.svg
 [forum]: https://community.home-assistant.io/t/home-assistant-community-add-on-visual-studio-code/107863?u=frenck
 [frenck]: https://github.com/frenck
-[github-actions-shield]: https://github.com/hassio-addons/addon-example/workflows/CI/badge.svg
-[github-actions]: https://github.com/hassio-addons/addon-example/actions
+[github-actions-shield]: https://github.com/hassio-addons/addon-vscode/workflows/CI/badge.svg
+[github-actions]: https://github.com/hassio-addons/addon-vscode/actions
 [github-sponsors-shield]: https://frenck.dev/wp-content/uploads/2019/12/github_sponsor.png
 [github-sponsors]: https://github.com/sponsors/frenck
 [i386-shield]: https://img.shields.io/badge/i386-no-red.svg


### PR DESCRIPTION
# Proposed Changes

The CI badge in the README showed the status of the example addon 🙈 
This PR fixes that.
