### PR TITLE
Common directories in /root like SSH add-on

### DIFF
--- a/vscode/DOCS.md
+++ b/vscode/DOCS.md
@@ -62,7 +62,9 @@ you are troubleshooting.
 
 This option allows you to override the default path the add-on will open
 when accessing the web interface. For example, use a different
-configuration directory like `/share/myconfig` instead of `/config`.
+configuration directory like `/share/myconfig` instead of `/config`. If set
+to `/root` then all the common folders of HA such as `/config`, `/ssl`, 
+`/share`, etc. will appear as subfolders for each access.
 
 When not configured, the addon will automatically use the default: `/config`
 

--- a/vscode/DOCS.md
+++ b/vscode/DOCS.md
@@ -63,7 +63,7 @@ you are troubleshooting.
 This option allows you to override the default path the add-on will open
 when accessing the web interface. For example, use a different
 configuration directory like `/share/myconfig` instead of `/config`. If set
-to `/root` then all the common folders of HA such as `/config`, `/ssl`, 
+to `/root` then all the common folders of HA such as `/config`, `/ssl`,
 `/share`, etc. will appear as subfolders for each access.
 
 When not configured, the addon will automatically use the default: `/config`

--- a/vscode/rootfs/etc/cont-init.d/user.sh
+++ b/vscode/rootfs/etc/cont-init.d/user.sh
@@ -3,10 +3,17 @@
 # Home Assistant Community Add-on: Visual Studio Code
 # Persists user settings and installs custom user packages.
 # ==============================================================================
+readonly -a DIRECTORIES=(addons backup config media share ssl)
 readonly GIT_USER_PATH=/data/git
 readonly SSH_USER_PATH=/data/.ssh
 readonly ZSH_HISTORY_FILE=/root/.zsh_history
 readonly ZSH_HISTORY_PERSISTANT_FILE=/data/.zsh_history
+
+# Links some common directories to the user's home folder for convenience
+for dir in "${DIRECTORIES[@]}"; do
+    ln -s "/${dir}" "${HOME}/${dir}" \
+        || bashio::log.warning "Failed linking common directory: ${dir}"
+done
 
 # Store SSH settings in add-on data folder
 if ! bashio::fs.directory_exists "${SSH_USER_PATH}"; then


### PR DESCRIPTION
# Proposed Changes

Set up links to common directories in `/root` like the SSH addon does. This way users can set `config_path` to `/root` and see everything HA uses and edit it.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
