### PR TITLE
⬆️ Upgrades Home Assistant CLI to v4.11.0

### DIFF
--- a/vscode/Dockerfile
+++ b/vscode/Dockerfile
@@ -86,7 +86,7 @@ RUN \
     && ls -la /root/.code-server/extensions/ \
     \
     && curl -L -s -o /usr/bin/ha \
-        "https://github.com/home-assistant/cli/releases/download/4.10.1/ha_${BUILD_ARCH}" \
+        "https://github.com/home-assistant/cli/releases/download/4.11.0/ha_${BUILD_ARCH}" \
     && chmod a+x /usr/bin/ha \
     \
     && git clone --branch master --single-branch --depth 1 \


### PR DESCRIPTION
# Proposed Changes

Upgrades Home Assistant CLI to v4.11.0

<https://github.com/home-assistant/cli/releases/tag/4.11.0>
