### PR TITLE
Address shellcheck lint warning

### DIFF
--- a/vscode/rootfs/root/.zshrc
+++ b/vscode/rootfs/root/.zshrc
@@ -63,7 +63,7 @@ plugins=(
     zsh-syntax-highlighting
 )
 
-# shellcheck-ignore: SC1091
+# shellcheck disable=SC1091
 source $ZSH/oh-my-zsh.sh
 
 # User configuration

--- a/vscode/rootfs/root/.zshrc
+++ b/vscode/rootfs/root/.zshrc
@@ -63,6 +63,7 @@ plugins=(
     zsh-syntax-highlighting
 )
 
+# shellcheck-ignore: SC1091
 source $ZSH/oh-my-zsh.sh
 
 # User configuration


### PR DESCRIPTION
# Proposed Changes

Ignoring a new linter warning, ignoring it, since I don't want to include oh-my-zsh in the shellcheck itself (not-following).
