### PR TITLE
⬆️ Upgrades code-server to 3.11.0

### DIFF
--- a/vscode/Dockerfile
+++ b/vscode/Dockerfile
@@ -53,7 +53,7 @@ RUN \
     && if [[ "${BUILD_ARCH}" = "aarch64" ]]; then ARCH="arm64"; fi \
     && if [[ "${BUILD_ARCH}" = "amd64" ]]; then ARCH="amd64"; fi \
     && curl -J -L -o /tmp/code.tar.gz \
-        "https://github.com/cdr/code-server/releases/download/v3.10.2/code-server-3.10.2-linux-${ARCH}.tar.gz" \
+        "https://github.com/cdr/code-server/releases/download/v3.11.0/code-server-3.11.0-linux-${ARCH}.tar.gz" \
     && mkdir -p /usr/local/lib/code-server \
     && tar zxvf \
         /tmp/code.tar.gz \


### PR DESCRIPTION
# Proposed Changes

Upgrades code-server to 3.11.0, which ships with VSCode 1.57.1
Upstream release notes: https://github.com/cdr/code-server/releases/tag/v3.11.0
