### PR TITLE
⬆️ Upgrades esbenp.prettier-vscode to 8.0.1

### DIFF
--- a/vscode/vscode.extensions
+++ b/vscode/vscode.extensions
@@ -1,5 +1,5 @@
 emilast.LogFileHighlighter#2.11.0
-esbenp.prettier-vscode#6.4.0
+esbenp.prettier-vscode#8.0.1
 ESPHome.esphome-vscode#0.20.0
 keesschollaart.vscode-home-assistant#1.20.0
 lukas-tr.materialdesignicons-intellisense#3.2.0


### PR DESCRIPTION
# Proposed Changes

Since we are running VSCode 1.57 now, we can upgrade prettier again.

https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md#801
