### PR TITLE
feat: Allow ingress via port with a password

### DIFF
--- a/vscode/DOCS.md
+++ b/vscode/DOCS.md
@@ -80,6 +80,13 @@ Customize your VSCode environment even more with the `init_commands` option.
 Add one or more shell commands to the list, and they will be executed every
 single time this add-on starts.
 
+### Option: `password`
+
+Set a password to access Code Server. By default, your Code Server instance
+is protected by Home Assistant's authentication. If you choose to expose
+Code Server to your network by setting a port, this option will be
+required.
+
 ## Resetting your VSCode settings to the add-on defaults
 
 The add-on updates your settings to be optimized for use with Home Assistant.

--- a/vscode/config.yaml
+++ b/vscode/config.yaml
@@ -30,6 +30,10 @@ services:
 options:
   packages: []
   init_commands: []
+ports:
+  1337/tcp: null
+ports_description:
+  1337/tcp: Code Server HTTP service (requires a configured password)
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   config_path: str?
@@ -37,3 +41,4 @@ schema:
     - str
   init_commands:
     - str
+  password: password?

--- a/vscode/rootfs/etc/services.d/code/run
+++ b/vscode/rootfs/etc/services.d/code/run
@@ -20,8 +20,15 @@ options+=(--host 0.0.0.0)
 options+=(--disable-telemetry)
 options+=(--disable-update-check)
 
-# Disable code authentication, we use HA authentication
-options+=(--auth none)
+# If exposed port or password is configured
+if [ -n "$(bashio::addon.port '1337/tcp')" ] || bashio::config.has_value 'password'; then
+    bashio::config.require.safe_password
+    options+=(--auth password)
+    export PASSWORD=$(bashio::config 'password')
+else
+    # Disable code authentication, we use HA authentication
+    options+=(--auth none)
+fi
 
 # Export env variables for the Home Assistant extension
 export HASS_SERVER="http://supervisor/core"


### PR DESCRIPTION
# Proposed Changes

This change allows a user to expose their code-server instance via the network port config, thus allowing directing access without going through the addon ingress.

Why would someone want to do this?

1. To be able to access code-server without the Home Assistant UI on the interface. When using code-server on a device with a smaller screen, like an iPad, every pixel of space counts.
2. To allow for mouse scrolling within code-server on an iPad. Currently, the Home Assistant UI puts code-server in an iframe, which consumes the iPad's mouse scroll events. While scroll events can be triggered correctly through touch, using a mouse on a iPad allows for a more desktop experience. (Note: this is definitely an issue with Mobile Safari and not Home Assistant, but the workaround is to not put code-server in an iframe.)

Since exposing code-server via a port removes Home Assistant's authentication, a password option was added. Setting the password is required if a port is configured, thus requiring the user to keep their code-server instance secure. The password is also checked against the haveibeenpwnd database using bashio tools.
