### PR TITLE
:fire: Remove Home Assistant CLI

### DIFF
--- a/vscode/requirements.txt
+++ b/vscode/requirements.txt
@@ -1,2 +1,1 @@
-homeassistant_cli==0.9.1
 yamllint==1.26.3


### PR DESCRIPTION
# Proposed Changes

This PR removes the Home Assistant CLI (this is `hass-cli`! The `ha` command will still be there). You can still add by setting a python-pip package to your add-on configuration.

