### PR TITLE
:fire: Remove hassio command compatibility layer

### DIFF
--- a/vscode/rootfs/usr/bin/hassio
+++ b/vscode/rootfs/usr/bin/hassio
@@ -1,3 +1,0 @@
-#!/usr/bin/env bashio
-bashio::log.yellow "The 'hassio' command is deprecated, please use 'ha' instead!"
-ha "$@"


### PR DESCRIPTION
# Proposed Changes

This PR cleans up the backward compatible `hassio` command. It has been replaced by the `ha` command a long time ago and has been throwing warnings for ages.

Time for it to go.
