### PR TITLE
Use shim instead of symlink for code CLI

### DIFF
--- a/vscode/Dockerfile
+++ b/vscode/Dockerfile
@@ -61,7 +61,6 @@ RUN \
         --strip 1 -C /usr/local/lib/code-server \
     \
     && ln -s /usr/local/lib/code-server/bin/code-server /usr/local/bin/code-server \
-    && ln -s /usr/local/lib/code-server/bin/code-server /usr/local/bin/code \
     \
     && mkdir -p /root/.code-server/extensions \
     && uuid=$(uuidgen) \

--- a/vscode/rootfs/usr/local/bin/code
+++ b/vscode/rootfs/usr/local/bin/code
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /usr/local/lib/code-server/bin/code-server "${@}"


### PR DESCRIPTION
# Proposed Changes

This changes the `code` CLI to be a shim rather than a symlink. When it's a symlink, the following does not work:

```console
$ echo "hello" | code -
[2023-02-28T00:10:43.853Z] error Unknown option -
```

But as a shim it works just fine:

```console
$ echo "hello" | code -
Reading from stdin via: /tmp/code-stdin-U2j
```

More information in the linked issue.

## Related Issues

- https://github.com/coder/code-server/issues/5693
