### PR TITLE
:hammer: Adjust upstream code-server org name

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -102,12 +102,12 @@
     {
       "groupName": "Add-on base image",
       "matchDatasources": ["docker"],
-      "matchUpdateTypes": ["patch"],
+      "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     },
     {
       "matchDatasources": ["github-releases"],
-      "matchDepNames": ["cdr/code-server"],
+      "matchDepNames": ["coder/code-server"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     },

--- a/vscode/Dockerfile
+++ b/vscode/Dockerfile
@@ -56,7 +56,7 @@ RUN \
     && if [[ "${BUILD_ARCH}" = "aarch64" ]]; then ARCH="arm64"; fi \
     && if [[ "${BUILD_ARCH}" = "amd64" ]]; then ARCH="amd64"; fi \
     && curl -J -L -o /tmp/code.tar.gz \
-        "https://github.com/cdr/code-server/releases/download/${CODE_SERVER_VERSION}/code-server-${CODE_SERVER_VERSION#v}-linux-${ARCH}.tar.gz" \
+        "https://github.com/coder/code-server/releases/download/${CODE_SERVER_VERSION}/code-server-${CODE_SERVER_VERSION#v}-linux-${ARCH}.tar.gz" \
     && mkdir -p /usr/local/lib/code-server \
     && tar zxvf \
         /tmp/code.tar.gz \


### PR DESCRIPTION
# Proposed Changes

The `cdr` org has been renamed to `coder`, this PR adjusts the URLs and links in the add-on source.
