### PR TITLE
🚑 Update healthcheck command

### DIFF
--- a/vscode/Dockerfile
+++ b/vscode/Dockerfile
@@ -131,9 +131,7 @@ COPY rootfs /
 
 # Health check
 HEALTHCHECK \
-    CMD curl --fail http://127.0.0.1:1337/healthz \
-        | jq --exit-status '.status == "alive"' \
-        || exit 1
+    CMD curl --fail http://127.0.0.1:1337/healthz || exit 1
 
 # Build arguments
 ARG BUILD_ARCH


### PR DESCRIPTION
# Proposed Changes

Update healthcheck command to basic curl request.  It would appear that the response from the endpoint is used to determine if there are active sessions on the server, as the responses appear to be either expired or active, it makes sense just to switch to a basic command.

## Related Issues

Fixes #666 
