### PR TITLE
Revert "⬆️ Update cdr/code-server to v4.17.0"

### DIFF
--- a/vscode/Dockerfile
+++ b/vscode/Dockerfile
@@ -20,7 +20,7 @@ COPY vscode.extensions /root/vscode.extensions
 
 # Setup base system
 ARG BUILD_ARCH=amd64
-ARG CODE_SERVER_VERSION="v4.17.0"
+ARG CODE_SERVER_VERSION="v4.16.1"
 ARG HA_CLI_VERSION="4.27.0"
 # hadolint ignore=SC2181, DL3008
 RUN \


### PR DESCRIPTION
Reverts hassio-addons/addon-vscode#701

This current breaks under aarch64 architectures.