### PR TITLE
init-user: Safeguarded linking directories and files

### DIFF
--- a/vscode/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
+++ b/vscode/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
@@ -12,14 +12,14 @@ readonly ZSH_HISTORY_PERSISTANT_FILE=/data/.zsh_history
 
 # Links some common directories to the user's home folder for convenience
 for dir in "${DIRECTORIES[@]}"; do
-    ln -s "/${dir}" "${HOME}/${dir}" \
+    ln -sn "/${dir}" "${HOME}/${dir}" \
         || bashio::log.warning "Failed linking common directory: ${dir}"
 done
 
 # Some links to old locations, to not mess with the user's muscle memory
-ln -s "/config" "${HOME}/config" \
+ln -sn "/config" "${HOME}/config" \
     || bashio::log.warning "Failed linking common directory: ${HOME}/config"
-ln -s "/config" "/homeassistant" \
+ln -sn "/config" "/homeassistant" \
     || bashio::log.warning "Failed linking common directory: /homeassistant"
 
 # Store SSH settings in add-on data folder
@@ -31,7 +31,7 @@ if ! bashio::fs.directory_exists "${SSH_USER_PATH}"; then
         || bashio::exit.nok \
             'Failed setting permissions on persistent .ssh folder'
 fi
-ln -s "${SSH_USER_PATH}" ~/.ssh
+ln -sn "${SSH_USER_PATH}" ~/.ssh || bashio::log.warning "Failed linking .ssh"
 
 # Sets up ZSH shell
 touch "${ZSH_HISTORY_PERSISTANT_FILE}" \
@@ -58,7 +58,7 @@ if ! bashio::fs.file_exists "${GIT_USER_PATH}/.gitconfig"; then
     touch "${GIT_USER_PATH}/.gitconfig" \
         || bashio::exit.nok 'Failed to create .gitconfig'
 fi
-ln -s "${GIT_USER_PATH}/.gitconfig" ~/.gitconfig
+ln -s "${GIT_USER_PATH}/.gitconfig" ~/.gitconfig || bashio::log.warning "Failed linking .gitconfig"
 
 # Install user configured/requested packages
 if bashio::config.has_value 'packages'; then


### PR DESCRIPTION
# Proposed Changes

This PR adds the `--no-dereference` (`-n`) flag for linking folders in order to avoid linking _too deep_ as a good practice.
It also convers linking errors of _.ssh_ and _.gitconfig_ to warnings via bashio to avoid s6 to crash the container for certain container deployment setups [1].

I observed that restarting the container (when deployed standalone [1]), the `init-user` script succeeds on the first container start without any problems. Another container restart however re-ran the init-user script, which caused two issues:
- Creation of links inside linked directories. E.g. `ln -s /config ${HOME}/config` created `/config/config` if `${HOME}/config` already existed.
- The container crashed because `init-user` tried to recreated existing links, that were not guarded via `||` like `ln -s src target || bashio::log.warning "The warning message"` that absorbed the non-zero return code of `ln` on failues (`.gitignore` and `.ssh`).

However (I hope this does not get too quickly discared as a **wont fix**):
For container-addons spawned by the HA supervisor, these issues might not appear when the container is deployed as it is intended via HA and the supervisor.
However, standalone deployments [1] will cause this issue. Since my proposed changes are just good practice, I hope you consider to add my minute changes.

[1] Standalone deployment for either testing, debugging etc or in my case: manually integrating the container in an already existing big docker stack without using the supervisor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the setup process to preserve your existing configuration files and directories without unintended overwrites, while maintaining robust error notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->