### PR TITLE
Revert "⬆️ Update cdr/code-server to v4.97.2 (#927)"

### DIFF
--- a/vscode/Dockerfile
+++ b/vscode/Dockerfile
@@ -20,7 +20,7 @@ COPY vscode.extensions /root/vscode.extensions
 
 # Setup base system
 ARG BUILD_ARCH=amd64
-ARG CODE_SERVER_VERSION="v4.97.2"
+ARG CODE_SERVER_VERSION="v4.96.4"
 ARG HA_CLI_VERSION="4.37.0"
 # hadolint ignore=SC2181, DL3008
 RUN \


### PR DESCRIPTION
This reverts commit 7e23ab4981ff1b3e7643b29c2b910fff78e4f75d.

It breaks everything 🗡️ 

See; https://github.com/coder/code-server/issues/7212


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the underlying server component to version v4.96.4 to ensure consistent installation and runtime behavior. No user-facing features have changed with this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->