### PR TITLE
Add python-venv to dockerfile

### DIFF
--- a/vscode/Dockerfile
+++ b/vscode/Dockerfile
@@ -41,6 +41,7 @@ RUN \
         openssh-client=1:9.2p1-2+deb12u5 \
         openssl=3.0.15-1~deb12u1 \
         python3-dev=3.11.2-1+b1 \
+        python3-venv=3.11.2-1+b1 \
         python3=3.11.2-1+b1 \
         unzip=6.0-28 \
         uuid-runtime=2.38.1-5+deb12u1 \


### PR DESCRIPTION
# Proposed Changes

The image includes esphome (thanks!), but compiling libretiny firmwares requires virtual environments. This PR simply adds the python-venv debian package to the build.

## Related Issues

None

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated package installation to include the python3-venv package for improved Python environment support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->