### PR TITLE
Remove netcorext.uuid-generator, it is now built-in the HA extension

### DIFF
--- a/vscode/vscode.extensions
+++ b/vscode/vscode.extensions
@@ -3,7 +3,6 @@ esbenp.prettier-vscode#11.0.0
 ESPHome.esphome-vscode#2023.9.0
 keesschollaart.vscode-home-assistant#2.0.0
 lukas-tr.materialdesignicons-intellisense#4.1.0
-netcorext.uuid-generator#0.0.5
 oderwat.indent-rainbow#8.3.1
 redhat.vscode-yaml#1.11.10112022
 usernamehw.errorlens#3.6.0


### PR DESCRIPTION
# Proposed Changes

SSIA
