### PR TITLE
Prevent the use of the root folder as workspace

### DIFF
--- a/vscode/DOCS.md
+++ b/vscode/DOCS.md
@@ -104,6 +104,11 @@ return to the defaults as delivered by this add-on, do the following:
   Although we support ARM devices, please be aware, that this add-on is quite
   heavy to run, and requires quite a bit of RAM. We do not recommended to run
   it on devices with less than 4Gb of memory.
+- **Do not use the root directory (`/`) as your workspace.** Opening the root
+  directory causes severe performance issues, as VS Code will attempt to index
+  the entire filesystem, resulting in excessive CPU and memory usage. Always
+  use `/config` (the default) or another specific directory. The add-on will
+  prevent startup if the root directory is configured as the workspace.
 - "Visual Studio Code is unable to watch for file changes in this large
   workspace" (error ENOSPC)
 

--- a/vscode/rootfs/etc/s6-overlay/s6-rc.d/init-code-server/run
+++ b/vscode/rootfs/etc/s6-overlay/s6-rc.d/init-code-server/run
@@ -28,6 +28,14 @@ if bashio::config.has_value 'config_path'; then
     if ! bashio::fs.directory_exists "${config_path}"; then
         bashio::exit.nok "Configured config path does not exists"
     fi
+    # Prevent using root directory as workspace to avoid performance issues
+    if [[ "${config_path}" == "/" ]]; then
+        bashio::exit.nok \
+            "Using the root directory (/) as workspace is not allowed. " \
+            "This causes severe performance issues as VS Code will index " \
+            "the entire filesystem. Please use /config or another specific " \
+            "directory instead."
+    fi
 fi
 
 # Ensure persistent data folder exists.


### PR DESCRIPTION
# Proposed Changes

To help with issue #800 

Using the root folder is very problematic. Add docs and prevent add-on startup when used.

../Frenck  

<p>
  <a href="https://www.linkedin.com/in/frenck/"><img src="https://github.com/frenck/frenck/raw/main/images/linkedin.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://youtube.com/@frenck"><img src="https://github.com/frenck/frenck/raw/main/images/youtube.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://bsky.app/profile/frenck.social"><img src="https://github.com/frenck/frenck/raw/main/images/bluesky.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://fosstodon.org/@frenck"><img src="https://github.com/frenck/frenck/raw/main/images/mastodon.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.instagram.com/frenck/"><img src="https://github.com/frenck/frenck/raw/main/images/instagram.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.threads.net/@frenck"><img src="https://github.com/frenck/frenck/raw/main/images/threads.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.facebook.com/frenck.dev/"><img src="https://github.com/frenck/frenck/raw/main/images/facebook.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://x.com/frenck"><img src="https://github.com/frenck/frenck/raw/main/images/x.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.tiktok.com/@frenck.nl"><img src="https://github.com/frenck/frenck/raw/main/images/tiktok.svg" width="18" height="18"></a>
</p>

Blogging my personal ramblings at <a href="https://frenck.dev">frenck.dev</a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workspace configuration guidance to advise against using the root directory, including performance risk warnings and recommendations for selecting alternative directories.

* **Bug Fixes**
  * Added startup validation that prevents the add-on from initializing if the root directory is configured as the workspace, with informative error messaging to guide users toward suitable alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->