### PR TITLE
Expose bundled Node.js on PATH for extensions

### DIFF
--- a/vscode/Dockerfile
+++ b/vscode/Dockerfile
@@ -65,6 +65,7 @@ RUN \
         --strip 1 -C /usr/local/lib/code-server \
     \
     && ln -s /usr/local/lib/code-server/bin/code-server /usr/local/bin/code-server \
+    && ln -sf /usr/local/lib/code-server/lib/node /usr/local/bin/node \
     \
     && mkdir -p /root/.code-server/extensions \
     && uuid=$(uuidgen) \


### PR DESCRIPTION
## Summary
- Code-server already bundles Node.js (currently v22.21.1) at `/usr/local/lib/code-server/lib/node`, but it is not on PATH
- Extensions that need a `node` binary (e.g., Claude Code) fail with "requires Node.js version 18 or higher"
- This adds a single symlink from the bundled Node.js to `/usr/local/bin/node` — no additional packages, no image size increase

Fixes #1091

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Node.js is now available in the system PATH within the code environment, making Node tools and commands directly accessible from the terminal. This improves developer convenience when running scripts, installing packages, or invoking Node-based utilities without additional configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->